### PR TITLE
Fix a UI bug in reading conditions and temperature

### DIFF
--- a/src/components/Conditions/ReviewTab.jsx
+++ b/src/components/Conditions/ReviewTab.jsx
@@ -136,8 +136,8 @@ export function ReviewTab() {
                   <div className="mb-3">
                     <h6 className="font-bold text-xs xs:text-sm text-gray-300 mb-1">Basic Settings:</h6>
                     <ul className="ml-3 xs:ml-4 space-y-1 text-xs xs:text-sm text-gray-300">
-                      <li><span className="font-semibold">Temperature:</span> <span className='font-medium'>{conditions.basic.temperature} K</span></li>
-                      <li><span className="font-semibold">Pressure:</span> <span className='font-medium'>{conditions.basic.pressure} Pa</span></li>
+                      <li><span className="font-semibold">Temperature:</span> <span className='font-medium'>{conditions.initial.temperature} K</span></li>
+                      <li><span className="font-semibold">Pressure:</span> <span className='font-medium'>{conditions.initial.pressure} Pa</span></li>
                       <li><span className="font-semibold">Duration:</span> <span className='font-medium'>{conditions.basic.duration} s ({(conditions.basic.duration / 3600).toFixed(2)} h)</span></li>
                       <li><span className="font-semibold">Time Step:</span> <span className='font-medium'>{conditions.basic.timeStep} s</span></li>
                     </ul>


### PR DESCRIPTION
Fix conditions and temperature read from `basic`, where they are not defined. 
`conditions.basic.temperature`
`conditions.basic.pressure`
They are defined in [initial](https://github.com/NCAR/music-box-interactive/blob/TAMU_Capstone_2026_UI/src/redux/slices/conditionsSlice.js#L13-L18)

```js
initial: {
  temperature: 298.15, // K
  pressure: 101325,    // Pa
  concentrations: {},
}
```