### PR TITLE
Fix a glob syntax and typos for deploy CI/CD script

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     tags:
-      - "v[0-9]+.[0-9].[0-9]"
+      - "v*.*.*"
 
 jobs:
   buildpush:
@@ -14,24 +14,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Get short sha
+    - name: Get short commit SHA
       run: echo "SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_ENV
 
-    - name: Chekcout Repo
+    - name: Checkout Repo
       uses: actions/checkout@v5
       with:
         ref: ${{ github.ref_name }}
         path: repo
         fetch-depth: 0
 
-    - name: Chekcout Deploy Branch
+    - name: Checkout Deploy Branch
       uses: actions/checkout@v5
       with:
         ref: deploy
         path: deploy
         fetch-depth: 0
 
-    - name: registry login
+    - name: Login to Docker Registry
       uses: docker/login-action@v3
       with:
         registry: hub.k8s.ucar.edu/musicbox

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -63,7 +63,7 @@ jobs:
         cd deploy/deploy/kustomization/overlays/devel
         kustomize edit set image  hub.k8s.ucar.edu/musicbox/frontend=hub.k8s.ucar.edu/musicbox/frontend:${{ env.SHORT_SHA }}
         kustomize edit set image  hub.k8s.ucar.edu/musicbox/backend=hub.k8s.ucar.edu/musicbox/backend:${{ env.SHORT_SHA }}
-        git config user.email "kyleshores@ucar.edu"
+        git config user.email "kshores@ucar.edu"
         git config user.name "Auto-ci"
         git add kustomization.yaml
         git commit -m "CI updating kustomization image tag"


### PR DESCRIPTION
This PR:
- Targets the `deploy` branch instead of `main`.
- Fixes a glob syntax for matching patterns in tag name
  - The current pattern `v[0-9]+.[0-9].[0-9]` won't work for tags like `v.1.13.13`, where minor and patch number requires two digits.
- Fixes two minor typos.  
 