### PR TITLE
Remove redundant next step buttons to simplify the UI

### DIFF
--- a/src/components/pages/ConditionsPage.jsx
+++ b/src/components/pages/ConditionsPage.jsx
@@ -8,7 +8,6 @@ import {
   ReviewTab,
 } from '../Conditions'
 import RunSimulationButton from '../RunSimulationButton'
-import NextStepButton from '../NextStepButton'
 
 /**
  * ConditionsPage Component
@@ -18,32 +17,13 @@ export function ConditionsPage() {
   const [activeTab, setActiveTab] = useState('basic') // 'basic' | 'initial' | 'evolving' | 'review'
 
   const tabs = [
-    {
-      id: 'basic',
-      label: 'General',
-      component: BasicConfigTab,
-      nextTab: 'initial',
-      nextLabel: 'Next to Initial Conditions',
-    },
-    {
-      id: 'initial',
-      label: 'Initial',
-      component: InitialConditionsTab,
-      nextTab: 'evolving',
-      nextLabel: 'Next to Evolving Conditions',
-    },
-    {
-      id: 'evolving',
-      label: 'Evolving',
-      component: EvolvingConditionsTab,
-      nextTab: 'review',
-      nextLabel: 'Next to Review Configuration',
-    },
+    { id: 'basic', label: 'General', component: BasicConfigTab },
+    { id: 'initial', label: 'Initial', component: InitialConditionsTab },
+    { id: 'evolving', label: 'Evolving', component: EvolvingConditionsTab },
     { id: 'review', label: 'Review', component: ReviewTab },
   ]
 
   const ActiveComponent = tabs.find((t) => t.id === activeTab)?.component
-  const currentTab = tabs.find((t) => t.id === activeTab)
 
   return (
     <div className="space-y-4">
@@ -69,18 +49,12 @@ export function ConditionsPage() {
               ))}
             </div>
 
-            {/* Next Step Button (non-review tabs) or Run Simulation Button (review tab) */}
-            <div className="flex justify-end">
-              {activeTab !== 'review' ? (
-                <NextStepButton
-                  onClick={() => setActiveTab(currentTab?.nextTab)}
-                  label={currentTab?.nextLabel || 'Next Step'}
-                  className="w-full xs:w-auto"
-                />
-              ) : (
+            {/* Run Simulation Button (review tab only) */}
+            {activeTab === 'review' && (
+              <div className="flex justify-end">
                 <RunSimulationButton className="w-full xs:w-auto" />
-              )}
-            </div>
+              </div>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/src/components/pages/ConditionsPage.jsx
+++ b/src/components/pages/ConditionsPage.jsx
@@ -7,7 +7,6 @@ import {
   EvolvingConditionsTab,
   ReviewTab,
 } from '../Conditions'
-import RunSimulationButton from '../RunSimulationButton'
 
 /**
  * ConditionsPage Component
@@ -48,13 +47,6 @@ export function ConditionsPage() {
                 </Button>
               ))}
             </div>
-
-            {/* Run Simulation Button (review tab only) */}
-            {activeTab === 'review' && (
-              <div className="flex justify-end">
-                <RunSimulationButton className="w-full xs:w-auto" />
-              </div>
-            )}
           </div>
         </CardContent>
       </Card>

--- a/src/components/pages/ConditionsPage.jsx
+++ b/src/components/pages/ConditionsPage.jsx
@@ -28,25 +28,22 @@ export function ConditionsPage() {
     <div className="space-y-4">
       {/* Tab Navigation */}
       <Card>
-        <CardContent className="pt-4 xs:pt-5 sm:pt-6">
-          <div className="space-y-3 xs:space-y-4">
-            {/* Tab Navigation */}
-            <div className="flex gap-1.5 xs:gap-2 border-b border-border pb-2 overflow-x-auto">
-              {tabs.map((tab) => (
-                <Button
-                  key={tab.id}
-                  variant="ghost"
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`rounded-2xl text-xs xs:text-sm sm:text-base px-2.5 xs:px-3 sm:px-4 py-1.5 xs:py-2 whitespace-nowrap flex-shrink-0 ${
-                    activeTab === tab.id
-                      ? 'border border-border bg-transparent text-action'
-                      : 'bg-transparent text-muted hover:bg-surface-hover hover:text-ink'
-                  }`}
-                >
-                  {tab.label}
-                </Button>
-              ))}
-            </div>
+        <CardContent className="pt-3 pb-3 xs:pt-4 xs:pb-4 sm:pt-4 sm:pb-4">
+          <div className="flex gap-1.5 xs:gap-2 overflow-x-auto">
+            {tabs.map((tab) => (
+              <Button
+                key={tab.id}
+                variant="ghost"
+                onClick={() => setActiveTab(tab.id)}
+                className={`rounded-2xl text-xs xs:text-sm sm:text-base px-2.5 xs:px-3 sm:px-4 py-1 xs:py-1.5 whitespace-nowrap flex-shrink-0 ${
+                  activeTab === tab.id
+                    ? 'border border-border bg-transparent text-action'
+                    : 'bg-transparent text-muted hover:bg-surface-hover hover:text-ink'
+                }`}
+              >
+                {tab.label}
+              </Button>
+            ))}
           </div>
         </CardContent>
       </Card>

--- a/src/components/pages/MechanismPage.jsx
+++ b/src/components/pages/MechanismPage.jsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react'
 import { Card, CardContent } from '../ui/card'
 import { Button } from '../ui/button'
 import { SpeciesEditor, ReactionEditor } from '../Mechanism'
-import NextStepButton from '../NextStepButton'
 import { useDispatch, useSelector } from 'react-redux'
 import { hydrateInitialConditions, hydrateEvolvingConditions } from '../../utils/hydrateConditions'
 import {
@@ -56,17 +55,10 @@ export function MechanismPage() {
 
   const tabs = [
     { id: 'species', label: 'Species', component: SpeciesEditor },
-    {
-      id: 'reactions',
-      label: 'Reactions',
-      component: ReactionEditor,
-      nextTo: '/conditions',
-      nextLabel: 'Next to Configure Conditions',
-    },
+    { id: 'reactions', label: 'Reactions', component: ReactionEditor},
   ]
 
   const ActiveComponent = tabs.find((t) => t.id === activeTab)?.component
-  const currentTab = tabs.find((t) => t.id === activeTab)
 
   return (
     <div className="space-y-4">
@@ -90,15 +82,6 @@ export function MechanismPage() {
                 </Button>
               ))}
             </div>
-
-            {/* Next button: Reactions tab -> Conditions page */}
-            {currentTab?.nextTo && (
-              <NextStepButton
-                to={currentTab.nextTo}
-                label={currentTab.nextLabel}
-                className="w-full xs:w-auto"
-              />
-            )}
           </div>
         </CardContent>
       </Card>

--- a/src/components/pages/MechanismPage.jsx
+++ b/src/components/pages/MechanismPage.jsx
@@ -55,13 +55,7 @@ export function MechanismPage() {
   }, [exampleFiles, currentExample, hydratedInitialId, hydratedEvolvingId, dispatch])
 
   const tabs = [
-    {
-      id: 'species',
-      label: 'Species',
-      component: SpeciesEditor,
-      nextTab: 'reactions',
-      nextLabel: 'Next to Add Reactions',
-    },
+    { id: 'species', label: 'Species', component: SpeciesEditor },
     {
       id: 'reactions',
       label: 'Reactions',
@@ -97,17 +91,11 @@ export function MechanismPage() {
               ))}
             </div>
 
-            {/* Next button: Species tab -> Reactions tab, Reactions tab -> Conditions page */}
-            {currentTab?.nextTab ? (
+            {/* Next button: Reactions tab -> Conditions page */}
+            {currentTab?.nextTo && (
               <NextStepButton
-                onClick={() => setActiveTab(currentTab.nextTab)}
+                to={currentTab.nextTo}
                 label={currentTab.nextLabel}
-                className="w-full xs:w-auto"
-              />
-            ) : (
-              <NextStepButton
-                to={currentTab?.nextTo}
-                label={currentTab?.nextLabel || 'Next Step'}
                 className="w-full xs:w-auto"
               />
             )}

--- a/src/components/pages/MechanismPage.jsx
+++ b/src/components/pages/MechanismPage.jsx
@@ -62,17 +62,17 @@ export function MechanismPage() {
 
   return (
     <div className="space-y-4">
-      {/* Tab Navigation with Next Step Button */}
+      {/* Tab Navigation */}
       <Card>
-        <CardContent className="pt-4 xs:pt-5 sm:pt-6">
-          <div className="flex flex-col xs:flex-row items-stretch xs:items-center justify-between gap-2 xs:gap-3 mb-2">
-            <div className="flex gap-1.5 xs:gap-2 border-b pb-2 flex-1 overflow-x-auto">
+        <CardContent className="pt-3 pb-3 xs:pt-4 xs:pb-4 sm:pt-4 sm:pb-4">
+          <div className="flex flex-col xs:flex-row items-stretch xs:items-center justify-between gap-2 xs:gap-3">
+            <div className="flex gap-1.5 xs:gap-2 flex-1 overflow-x-auto">
               {tabs.map((tab) => (
                 <Button
                   key={tab.id}
                   variant="ghost"
                   onClick={() => setActiveTab(tab.id)}
-                  className={`rounded-2xl text-xs xs:text-sm sm:text-base px-3 xs:px-4 sm:px-6 py-1.5 xs:py-2 whitespace-nowrap flex-shrink-0 ${
+                  className={`rounded-2xl text-xs xs:text-sm sm:text-base px-3 xs:px-4 sm:px-6 py-1 xs:py-1.5 whitespace-nowrap flex-shrink-0 ${
                     activeTab === tab.id
                       ? 'border border-border bg-transparent text-action'
                       : 'bg-transparent text-muted hover:bg-surface-hover hover:text-ink'

--- a/src/components/pages/PlotsPage.jsx
+++ b/src/components/pages/PlotsPage.jsx
@@ -24,8 +24,8 @@ export function PlotsPage() {
     <div className="space-y-4">
       {/* Tab Navigation */}
       <Card>
-        <CardContent className="pt-4 xs:pt-5 sm:pt-6">
-          <div className="flex flex-col xs:flex-row gap-2 border-b pb-2 overflow-x-auto">
+        <CardContent className="pt-3 pb-3 xs:pt-4 xs:pb-4 sm:pt-4 sm:pb-4">
+          <div className="flex flex-col xs:flex-row gap-2 overflow-x-auto">
             {tabs.map((tab) => {
               const IconComponent = tab.Icon
               return (
@@ -33,7 +33,7 @@ export function PlotsPage() {
                   key={tab.id}
                   variant="ghost"
                   onClick={() => setActiveTab(tab.id)}
-                  className={`rounded-2xl text-xs xs:text-sm sm:text-base px-3 xs:px-4 py-2 whitespace-nowrap flex-shrink-0 ${
+                  className={`rounded-2xl text-xs xs:text-sm sm:text-base px-3 xs:px-4 py-1 xs:py-1.5 whitespace-nowrap flex-shrink-0 ${
                     activeTab === tab.id
                       ? 'border border-border bg-transparent text-action'
                       : 'bg-transparent text-muted hover:bg-surface-hover hover:text-ink'


### PR DESCRIPTION
This PR:
- Removes the next step buttons to simplify the UI. 
  -  Next step buttons are redundant since the tabs provide navigation between steps. 
- Removes the gray line under the tabs
- Reduces the height of the tab bar for better layout
- Closes #542 