### PR TITLE
Improve plot visualization and search experience

### DIFF
--- a/.github/workflows/close_issues_on_merge.yml
+++ b/.github/workflows/close_issues_on_merge.yml
@@ -36,5 +36,5 @@ jobs:
                 gh issue close "$issue" \
                   --repo "$REPO" \
                   --reason completed \
-                  --comment "Automatically closed by PR #$PR_NUMBER merged into branch $BASE_REF."
+                  --comment "Automatically closed by PR #$PR_NUMBER merged into $BASE_REF branch."
               done

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -10,7 +10,7 @@ import {
   ResponsiveContainer,
   Label,
 } from 'recharts'
-import { BarChart3, Atom, AlertCircle, Lightbulb, ChevronDown, Check } from 'lucide-react'
+import { BarChart3, Atom, AlertCircle, ChevronDown, Check } from 'lucide-react'
 import { Card, CardContent, CardDescription } from './ui/card'
 import { getSpeciesDisplayName } from './Plots/speciesFormat'
 import { useClickOutside } from '../hooks/useClickOutside'
@@ -715,7 +715,7 @@ export function SimulationChart({ results, metadata }) {
         </div>
 
         {/* Summary Box */}
-        <div className="text-xs text-gray-600 bg-blue-50 border border-blue-200 rounded-lg p-3">
+        <div className="text-xs text-gray-600 bg-blue-50/40 border border-blue-200 rounded-lg p-3">
           <p className="font-semibold text-sm mb-1 flex items-center gap-2">
             <BarChart3 className="w-4 h-4" />
             Summary:
@@ -737,27 +737,6 @@ export function SimulationChart({ results, metadata }) {
             <br />
             • {results.length} {"\u00A0"}data points
           </CardDescription>
-        </div>
-
-        {/* Info Box */}
-        <div className="text-xs text-gray-600 bg-gray-50 border border-gray-200 rounded-lg p-3">
-          <p className="font-semibold mb-1 flex items-center gap-2">
-            <Lightbulb className="w-4 h-4" />
-            Chart Controls:
-          </p>
-          <ul className="space-y-0.5 ml-4">
-            <li>
-              • Chart displays concentrations on <strong>logarithmic scale</strong> with dynamic
-              axes
-            </li>
-            <li>
-              • Click species badges to <strong>show/hide</strong> individual species
-            </li>
-            <li>
-              • Use <strong>Show All</strong> to display all species simultaneously
-            </li>
-            <li>• Hover over the chart for detailed concentration values</li>
-          </ul>
         </div>
       </CardContent>
     </Card>

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -286,7 +286,7 @@ export function SimulationChart({ results, metadata }) {
         )}
 
         {/* Species Filter */}
-        <div className="border rounded-lg p-2 xs:p-3 sm:p-4 bg-gray-50">
+        <div className="border rounded-lg p-2 xs:p-3 sm:p-4 bg-gray-50 mt-2 xs:mt-3 sm:mt-4">
           <div className="flex flex-col xs:flex-row items-start xs:items-center justify-between gap-2 xs:gap-0 mb-3">
             <div className="flex flex-wrap items-center justify-between gap-3 w-full">
               <div className="flex items-center border border-gray-300 rounded-lg divide-x divide-gray-300 bg-white">
@@ -567,7 +567,7 @@ export function SimulationChart({ results, metadata }) {
 
           {/* Larger chart for bigger screens */}
           <ResponsiveContainer width="100%" height={600} className="hidden xs:block">
-            <LineChart data={chartData} margin={{ top: 5, right: 30, left: 80, bottom: 5 }}>
+            <LineChart data={chartData} margin={{ top: 5, right: 30, left: 30, bottom: 5 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
 
               <XAxis

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -18,7 +18,6 @@ import { getSpeciesDisplayName } from './Plots/speciesFormat'
 // X-axis time unit options: seconds are converted by dividing by `divisor`
 const TIME_UNITS = [
   { id: 'seconds', label: 'Seconds', axisLabel: 'Time (s)', suffix: 's', divisor: 1 },
-  { id: 'minutes', label: 'Minutes', axisLabel: 'Time (min)', suffix: 'min', divisor: 60 },
   { id: 'hours', label: 'Hours', axisLabel: 'Time (hr)', suffix: 'hr', divisor: 3600 },
 ]
 
@@ -123,6 +122,20 @@ export function SimulationChart({ results, metadata }) {
       return point
     })
   }, [results, allSpecies, timeUnit.divisor])
+
+  // Fixed-percentage padding so the axis bounds stay visually consistent across time units
+  // (Recharts' 'auto' domain picks "nice" round numbers whose padding ratio varies with magnitude)
+  const timeDomain = useMemo(() => {
+    const times = chartData.map((point) => point.timeSeconds).filter((t) => isFinite(t))
+    if (times.length === 0) return [0, 1]
+
+    const minTime = Math.min(...times)
+    const maxTime = Math.max(...times)
+    if (minTime === maxTime) return [Math.max(0, minTime - 1), maxTime + 1]
+
+    const padding = (maxTime - minTime) * 0.05
+    return [Math.max(0, minTime - padding), maxTime + padding]
+  }, [chartData])
 
   // Toggle species selection
   const toggleSpecies = (species) => {
@@ -313,7 +326,7 @@ export function SimulationChart({ results, metadata }) {
 
               <XAxis
                 dataKey="timeSeconds"
-                domain={['auto', 'auto']}
+                domain={timeDomain}
                 stroke="#374151"
                 tick={{ fontSize: 10, fill: '#374151' }}
                 type="number"
@@ -427,7 +440,7 @@ export function SimulationChart({ results, metadata }) {
 
               <XAxis
                 dataKey="timeSeconds"
-                domain={['auto', 'auto']}
+                domain={timeDomain}
                 stroke="#374151"
                 tick={{ fontSize: 12, fill: '#374151' }}
                 type="number"

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -286,7 +286,7 @@ export function SimulationChart({ results, metadata }) {
         )}
 
         {/* Species Filter */}
-        <div className="border rounded-lg p-2 xs:p-3 sm:p-4 bg-gray-50 mt-2 xs:mt-3 sm:mt-4">
+        <div className="rounded-lg p-2 xs:p-3 sm:p-4 bg-gray-50 mt-2 xs:mt-3 sm:mt-4">
           <div className="flex flex-col xs:flex-row items-start xs:items-center justify-between gap-2 xs:gap-0 mb-3">
             <div className="flex flex-wrap items-center justify-between gap-3 w-full">
               <div className="flex items-center border border-gray-300 rounded-lg divide-x divide-gray-300 bg-white">

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -10,7 +10,7 @@ import {
   ResponsiveContainer,
   Label,
 } from 'recharts'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
+import { Card, CardContent, CardDescription, CardTitle } from './ui/card'
 import { Button } from './ui/button'
 import { BarChart3, Atom, AlertCircle, Lightbulb } from 'lucide-react'
 import { getSpeciesDisplayName } from './Plots/speciesFormat'
@@ -25,7 +25,7 @@ const TIME_UNITS = [
 // solver output); other units require a conversion function (e.g. ppb needs the
 // ideal gas law with per-point temperature/pressure) that isn't implemented yet.
 const PLOT_UNITS = [
-  { id: 'mol_m3', label: 'mol/m³', axisLabel: 'Concentration (mol m⁻³)', supported: true },
+  { id: 'mol_m3', label: 'mol m-3', axisLabel: 'Concentration (mol m⁻³)', supported: true },
   { id: 'ppb', label: 'ppb', axisLabel: 'Concentration (ppb)', supported: false },
 ]
 
@@ -251,18 +251,6 @@ export function SimulationChart({ results, metadata }) {
 
   return (
     <Card>
-      <CardHeader>
-        <div>
-          <CardTitle className="text-base xs:text-lg sm:text-xl">
-            Concentration Profiles (Log Scale)
-          </CardTitle>
-          <CardDescription className="text-xs xs:text-sm">
-            {metadata?.mechanism?.toUpperCase()} mechanism •{metadata?.duration?.toLocaleString()}{' '}
-            seconds •{results.length} data points
-          </CardDescription>
-        </div>
-      </CardHeader>
-
       <CardContent className="space-y-3 xs:space-y-4">
         {/* Warning for insufficient data points */}
         {results.length < 3 && (
@@ -339,7 +327,7 @@ export function SimulationChart({ results, metadata }) {
         {/* Plot Unit / Time Unit Selectors */}
         <div className="flex flex-wrap items-center gap-4 xs:gap-6">
           <div className="flex items-center gap-2 xs:gap-3">
-            <h4 className="font-semibold text-xs xs:text-sm text-gray-900">Plot Unit:</h4>
+            <h4 className="font-semibold text-xs xs:text-sm text-gray-900">Plot unit:</h4>
             <select
               value={plotUnitId}
               onChange={(e) => setPlotUnitId(e.target.value)}
@@ -360,7 +348,7 @@ export function SimulationChart({ results, metadata }) {
           </div>
 
           <div className="flex items-center gap-2 xs:gap-3">
-            <h4 className="font-semibold text-xs xs:text-sm text-gray-900">Time Unit:</h4>
+            <h4 className="font-semibold text-xs xs:text-sm text-gray-900">Time unit:</h4>
             <select
               value={timeUnitId}
               onChange={(e) => setTimeUnitId(e.target.value)}
@@ -642,6 +630,16 @@ export function SimulationChart({ results, metadata }) {
               ))}
             </LineChart>
           </ResponsiveContainer>
+        </div>
+
+        <div>
+          <CardTitle className="text-base xs:text-lg sm:text-xl">
+            Concentration Profiles (Log Scale)
+          </CardTitle>
+          <CardDescription className="text-xs xs:text-sm">
+            {metadata?.mechanism?.toUpperCase()} mechanism •{metadata?.duration?.toLocaleString()}{' '}
+            seconds •{results.length} data points
+          </CardDescription>
         </div>
 
         {/* Info Box */}

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -21,6 +21,14 @@ const TIME_UNITS = [
   { id: 'hours', label: 'Hours', axisLabel: 'Time (hr)', suffix: 'hr', divisor: 3600 },
 ]
 
+// Round x up to the nearest "nice" number (1, 2, 5, or 10 times a power of 10)
+function niceNumber(x) {
+  const exponent = Math.floor(Math.log10(x))
+  const fraction = x / 10 ** exponent
+  const niceFraction = fraction <= 1 ? 1 : fraction <= 2 ? 2 : fraction <= 5 ? 5 : 10
+  return niceFraction * 10 ** exponent
+}
+
 /**
  * SimulationChart Component
  * Displays atmospheric chemistry concentration data with interactive controls
@@ -136,6 +144,28 @@ export function SimulationChart({ results, metadata }) {
     const padding = (maxTime - minTime) * 0.05
     return [Math.max(0, minTime - padding), maxTime + padding]
   }, [chartData])
+
+  // For Hours, pick a "nice" step (always a multiple of 0.5 hr) that yields roughly
+  // TARGET_HOUR_TICKS gridlines regardless of simulation length, instead of always
+  // stepping by 0.5 hr (which gets cluttered on long runs) or Recharts' auto step
+  // (which picks arbitrary, non-0.5-hr-aligned values).
+  const HOUR_TICK_STEP = 0.5
+  const TARGET_HOUR_TICKS = 5
+  const xAxisTicks = useMemo(() => {
+    if (timeUnit.id !== 'hours') return undefined
+
+    const maxDomain = timeDomain[1]
+    if (maxDomain <= 0) return [0]
+
+    const rawStep = maxDomain / TARGET_HOUR_TICKS
+    const step = Math.ceil(niceNumber(rawStep) / HOUR_TICK_STEP) * HOUR_TICK_STEP
+
+    const ticks = []
+    for (let t = 0; t <= maxDomain + 1e-9; t += step) {
+      ticks.push(Math.round(t * 1000) / 1000)
+    }
+    return ticks
+  }, [timeUnit.id, timeDomain])
 
   // Toggle species selection
   const toggleSpecies = (species) => {
@@ -327,6 +357,7 @@ export function SimulationChart({ results, metadata }) {
               <XAxis
                 dataKey="timeSeconds"
                 domain={timeDomain}
+                ticks={xAxisTicks}
                 stroke="#374151"
                 tick={{ fontSize: 10, fill: '#374151' }}
                 type="number"
@@ -441,6 +472,7 @@ export function SimulationChart({ results, metadata }) {
               <XAxis
                 dataKey="timeSeconds"
                 domain={timeDomain}
+                ticks={xAxisTicks}
                 stroke="#374151"
                 tick={{ fontSize: 12, fill: '#374151' }}
                 type="number"

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react'
 import {
   LineChart,
   Line,
@@ -12,8 +12,9 @@ import {
 } from 'recharts'
 import { Card, CardContent, CardDescription, CardTitle } from './ui/card'
 import { Button } from './ui/button'
-import { BarChart3, Atom, AlertCircle, Lightbulb } from 'lucide-react'
+import { BarChart3, Atom, AlertCircle, Lightbulb, ChevronDown, Check } from 'lucide-react'
 import { getSpeciesDisplayName } from './Plots/speciesFormat'
+import { useClickOutside } from '../hooks/useClickOutside'
 
 // X-axis time unit options: seconds are converted by dividing by `divisor`
 const TIME_UNITS = [
@@ -25,7 +26,7 @@ const TIME_UNITS = [
 // solver output); other units require a conversion function (e.g. ppb needs the
 // ideal gas law with per-point temperature/pressure) that isn't implemented yet.
 const PLOT_UNITS = [
-  { id: 'mol_m3', label: 'mol m-3', axisLabel: 'Concentration (mol m⁻³)', supported: true },
+  { id: 'mol_m3', label: 'mol m-3', axisLabel: 'Concentration (mol m-3)', supported: true },
   { id: 'ppb', label: 'ppb', axisLabel: 'Concentration (ppb)', supported: false },
 ]
 
@@ -51,9 +52,18 @@ export function SimulationChart({ results, metadata }) {
   const [initialized, setInitialized] = useState(false)
   const [timeUnitId, setTimeUnitId] = useState('seconds')
   const [plotUnitId, setPlotUnitId] = useState('mol_m3')
+  const [plotUnitMenuOpen, setPlotUnitMenuOpen] = useState(false)
+  const [timeUnitMenuOpen, setTimeUnitMenuOpen] = useState(false)
+  const plotUnitMenuRef = useRef(null)
+  const timeUnitMenuRef = useRef(null)
 
   const timeUnit = TIME_UNITS.find((u) => u.id === timeUnitId) ?? TIME_UNITS[0]
   const plotUnit = PLOT_UNITS.find((u) => u.id === plotUnitId) ?? PLOT_UNITS[0]
+
+  const closePlotUnitMenu = useCallback(() => setPlotUnitMenuOpen(false), [])
+  const closeTimeUnitMenu = useCallback(() => setTimeUnitMenuOpen(false), [])
+  useClickOutside(plotUnitMenuRef, closePlotUnitMenu, plotUnitMenuOpen)
+  useClickOutside(timeUnitMenuRef, closeTimeUnitMenu, timeUnitMenuOpen)
 
   // Color palette for species
   const colors = [
@@ -326,40 +336,78 @@ export function SimulationChart({ results, metadata }) {
 
         {/* Plot Unit / Time Unit Selectors */}
         <div className="flex flex-wrap items-center gap-4 xs:gap-6">
-          <div className="flex items-center gap-2 xs:gap-3">
-            <h4 className="font-semibold text-xs xs:text-sm text-gray-900">Plot unit:</h4>
-            <select
-              value={plotUnitId}
-              onChange={(e) => setPlotUnitId(e.target.value)}
-              className="border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+          <div className="relative" ref={plotUnitMenuRef}>
+            <button
+              type="button"
+              onClick={() => setPlotUnitMenuOpen((open) => !open)}
+              className="flex items-center gap-1.5 border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
             >
-              {PLOT_UNITS.map((unit) => (
-                <option
-                  key={unit.id}
-                  value={unit.id}
-                  disabled={!unit.supported}
-                  title={!unit.supported ? 'Conversion not yet supported' : undefined}
-                >
-                  {unit.label}
-                  {!unit.supported ? ' (coming soon)' : ''}
-                </option>
-              ))}
-            </select>
+              {plotUnit.label}
+              <ChevronDown className="w-3.5 h-3.5" />
+            </button>
+
+            {plotUnitMenuOpen && (
+              <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
+                {PLOT_UNITS.map((unit) => (
+                  <button
+                    key={unit.id}
+                    type="button"
+                    disabled={!unit.supported}
+                    title={!unit.supported ? 'Conversion not yet supported' : undefined}
+                    onClick={() => {
+                      setPlotUnitId(unit.id)
+                      setPlotUnitMenuOpen(false)
+                    }}
+                    className={`w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 ${
+                      unit.supported
+                        ? 'text-gray-800 hover:bg-gray-100'
+                        : 'text-gray-400 cursor-not-allowed'
+                    }`}
+                  >
+                    <Check
+                      className={`w-3.5 h-3.5 flex-shrink-0 ${
+                        plotUnitId === unit.id ? 'opacity-100' : 'opacity-0'
+                      }`}
+                    />
+                    {unit.label}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
 
-          <div className="flex items-center gap-2 xs:gap-3">
-            <h4 className="font-semibold text-xs xs:text-sm text-gray-900">Time unit:</h4>
-            <select
-              value={timeUnitId}
-              onChange={(e) => setTimeUnitId(e.target.value)}
-              className="border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+          <div className="relative" ref={timeUnitMenuRef}>
+            <button
+              type="button"
+              onClick={() => setTimeUnitMenuOpen((open) => !open)}
+              className="flex items-center gap-1.5 border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
             >
-              {TIME_UNITS.map((unit) => (
-                <option key={unit.id} value={unit.id}>
-                  {unit.label}
-                </option>
-              ))}
-            </select>
+              {timeUnit.label}
+              <ChevronDown className="w-3.5 h-3.5" />
+            </button>
+
+            {timeUnitMenuOpen && (
+              <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
+                {TIME_UNITS.map((unit) => (
+                  <button
+                    key={unit.id}
+                    type="button"
+                    onClick={() => {
+                      setTimeUnitId(unit.id)
+                      setTimeUnitMenuOpen(false)
+                    }}
+                    className="w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 text-gray-800 hover:bg-gray-100"
+                  >
+                    <Check
+                      className={`w-3.5 h-3.5 flex-shrink-0 ${
+                        timeUnitId === unit.id ? 'opacity-100' : 'opacity-0'
+                      }`}
+                    />
+                    {unit.label}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -289,137 +289,141 @@ export function SimulationChart({ results, metadata }) {
         <div className="border rounded-lg p-2 xs:p-3 sm:p-4 bg-gray-50">
           <div className="flex flex-col xs:flex-row items-start xs:items-center justify-between gap-2 xs:gap-0 mb-3">
             <div className="flex items-center gap-3 w-full xs:w-auto">
-              <div className="relative" ref={selectAllMenuRef}>
-                <button
-                  type="button"
-                  onClick={() => setSelectAllMenuOpen((open) => !open)}
-                  className="flex items-center gap-1.5 border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                >
-                  {selectAllStatusLabel}
-                  <ChevronDown className="w-3.5 h-3.5" />
-                </button>
+              <div className="flex items-center border border-gray-300 rounded-lg divide-x divide-gray-300 bg-white">
+                <div className="relative" ref={selectAllMenuRef}>
+                  <button
+                    type="button"
+                    onClick={() => setSelectAllMenuOpen((open) => !open)}
+                    className="flex items-center gap-1.5 text-gray-800 rounded-l-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                  >
+                    {selectAllStatusLabel}
+                    <ChevronDown className="w-3.5 h-3.5" />
+                  </button>
 
-                {selectAllMenuOpen && (
-                  <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setSelectedSpecies(filteredSpecies)
-                        setSelectAllMenuOpen(false)
-                      }}
-                      className="w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 text-gray-800 hover:bg-gray-100"
-                    >
-                      <Check
-                        className={`w-3.5 h-3.5 flex-shrink-0 ${
-                          allFilteredSelected ? 'opacity-100' : 'opacity-0'
-                        }`}
-                      />
-                      Select all
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setSelectedSpecies([])
-                        setSelectAllMenuOpen(false)
-                      }}
-                      className="w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 text-gray-800 hover:bg-gray-100"
-                    >
-                      <Check
-                        className={`w-3.5 h-3.5 flex-shrink-0 ${
-                          noneSelected ? 'opacity-100' : 'opacity-0'
-                        }`}
-                      />
-                      Deselect all
-                    </button>
-                  </div>
-                )}
-              </div>
-
-              {/* Search bar for species filter */}
-              <input
-                type="text"
-                value={speciesSearch}
-                onChange={(e) => setSpeciesSearch(e.target.value)}
-                placeholder="Search species"
-                className="flex-1 max-w-xs px-3 py-2 border-2 border-gray-300 bg-white text-gray-800 placeholder:text-gray-400 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-600"
-              />
-
-              <h4 className="font-semibold text-xs xs:text-sm text-gray-900">
-                ({displaySpecies.length} selected)
-              </h4>
-
-              <div className="relative" ref={plotUnitMenuRef}>
-                <button
-                  type="button"
-                  onClick={() => setPlotUnitMenuOpen((open) => !open)}
-                  className="flex items-center gap-1.5 border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                >
-                  {plotUnit.label}
-                  <ChevronDown className="w-3.5 h-3.5" />
-                </button>
-
-                {plotUnitMenuOpen && (
-                  <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
-                    {PLOT_UNITS.map((unit) => (
+                  {selectAllMenuOpen && (
+                    <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
                       <button
-                        key={unit.id}
-                        type="button"
-                        disabled={!unit.supported}
-                        title={!unit.supported ? 'Conversion not yet supported' : undefined}
-                        onClick={() => {
-                          setPlotUnitId(unit.id)
-                          setPlotUnitMenuOpen(false)
-                        }}
-                        className={`w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 ${
-                          unit.supported
-                            ? 'text-gray-800 hover:bg-gray-100'
-                            : 'text-gray-400 cursor-not-allowed'
-                        }`}
-                      >
-                        <Check
-                          className={`w-3.5 h-3.5 flex-shrink-0 ${
-                            plotUnitId === unit.id ? 'opacity-100' : 'opacity-0'
-                          }`}
-                        />
-                        {unit.label}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div className="relative" ref={timeUnitMenuRef}>
-                <button
-                  type="button"
-                  onClick={() => setTimeUnitMenuOpen((open) => !open)}
-                  className="flex items-center gap-1.5 border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
-                >
-                  {timeUnit.label}
-                  <ChevronDown className="w-3.5 h-3.5" />
-                </button>
-
-                {timeUnitMenuOpen && (
-                  <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
-                    {TIME_UNITS.map((unit) => (
-                      <button
-                        key={unit.id}
                         type="button"
                         onClick={() => {
-                          setTimeUnitId(unit.id)
-                          setTimeUnitMenuOpen(false)
+                          setSelectedSpecies(filteredSpecies)
+                          setSelectAllMenuOpen(false)
                         }}
                         className="w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 text-gray-800 hover:bg-gray-100"
                       >
                         <Check
                           className={`w-3.5 h-3.5 flex-shrink-0 ${
-                            timeUnitId === unit.id ? 'opacity-100' : 'opacity-0'
+                            allFilteredSelected ? 'opacity-100' : 'opacity-0'
                           }`}
                         />
-                        {unit.label}
+                        Select all
                       </button>
-                    ))}
-                  </div>
-                )}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setSelectedSpecies([])
+                          setSelectAllMenuOpen(false)
+                        }}
+                        className="w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 text-gray-800 hover:bg-gray-100"
+                      >
+                        <Check
+                          className={`w-3.5 h-3.5 flex-shrink-0 ${
+                            noneSelected ? 'opacity-100' : 'opacity-0'
+                          }`}
+                        />
+                        Deselect all
+                      </button>
+                    </div>
+                  )}
+                </div>
+
+                {/* Search bar for species filter */}
+                <input
+                  type="text"
+                  value={speciesSearch}
+                  onChange={(e) => setSpeciesSearch(e.target.value)}
+                  placeholder="Search species"
+                  className="flex-1 max-w-xs px-3 py-2 text-gray-800 placeholder:text-gray-400 rounded-r-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-600"
+                />
+              </div>
+
+              <h4 className="font-semibold text-xs xs:text-sm text-gray-900">
+                ({displaySpecies.length} selected)
+              </h4>
+
+              <div className="flex items-center border border-gray-300 rounded-lg divide-x divide-gray-300 bg-white">
+                <div className="relative" ref={plotUnitMenuRef}>
+                  <button
+                    type="button"
+                    onClick={() => setPlotUnitMenuOpen((open) => !open)}
+                    className="flex items-center gap-1.5 text-gray-800 rounded-l-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                  >
+                    {plotUnit.label}
+                    <ChevronDown className="w-3.5 h-3.5" />
+                  </button>
+
+                  {plotUnitMenuOpen && (
+                    <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
+                      {PLOT_UNITS.map((unit) => (
+                        <button
+                          key={unit.id}
+                          type="button"
+                          disabled={!unit.supported}
+                          title={!unit.supported ? 'Conversion not yet supported' : undefined}
+                          onClick={() => {
+                            setPlotUnitId(unit.id)
+                            setPlotUnitMenuOpen(false)
+                          }}
+                          className={`w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 ${
+                            unit.supported
+                              ? 'text-gray-800 hover:bg-gray-100'
+                              : 'text-gray-400 cursor-not-allowed'
+                          }`}
+                        >
+                          <Check
+                            className={`w-3.5 h-3.5 flex-shrink-0 ${
+                              plotUnitId === unit.id ? 'opacity-100' : 'opacity-0'
+                            }`}
+                          />
+                          {unit.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                <div className="relative" ref={timeUnitMenuRef}>
+                  <button
+                    type="button"
+                    onClick={() => setTimeUnitMenuOpen((open) => !open)}
+                    className="flex items-center gap-1.5 text-gray-800 rounded-r-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                  >
+                    {timeUnit.label}
+                    <ChevronDown className="w-3.5 h-3.5" />
+                  </button>
+
+                  {timeUnitMenuOpen && (
+                    <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
+                      {TIME_UNITS.map((unit) => (
+                        <button
+                          key={unit.id}
+                          type="button"
+                          onClick={() => {
+                            setTimeUnitId(unit.id)
+                            setTimeUnitMenuOpen(false)
+                          }}
+                          className="w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 text-gray-800 hover:bg-gray-100"
+                        >
+                          <Check
+                            className={`w-3.5 h-3.5 flex-shrink-0 ${
+                              timeUnitId === unit.id ? 'opacity-100' : 'opacity-0'
+                            }`}
+                          />
+                          {unit.label}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -718,14 +718,24 @@ export function SimulationChart({ results, metadata }) {
           </ResponsiveContainer>
         </div>
 
-        <div>
+        {/* Summary Box */}
+        <div className="text-xs text-gray-600 bg-blue-50 border border-blue-200 rounded-lg p-3">
           <CardDescription className="text-xs xs:text-sm">
-            {metadata?.mechanism?.toUpperCase()} {"\u00A0"}{"\u00A0"} mechanism
+            • {metadata?.mechanism?.toUpperCase()}
+            {metadata?.mechanism &&
+              !metadata.mechanism.toLowerCase().includes('mechanism') && (
+                <>{"\u00A0"}mechanism</>
+              )}
             <br />
-            {metadata?.duration?.toLocaleString()}  seconds
-            {metadata?.duration != null && `   |   ${(metadata.duration / 3600).toFixed(2)}  hours`}
+            • {metadata?.duration?.toLocaleString()} {"\u00A0"}seconds
+            {metadata?.duration != null && (
+              <>
+                {"\u00A0"}{"\u00A0"}|{"\u00A0"}{"\u00A0"}
+                {(metadata.duration / 3600).toFixed(1)} {"\u00A0"}hours
+              </>
+            )}
             <br />
-            {results.length}&nbsp;&nbsp;data points
+            • {results.length} {"\u00A0"}data points
           </CardDescription>
         </div>
 

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -10,7 +10,7 @@ import {
   ResponsiveContainer,
   Label,
 } from 'recharts'
-import { Card, CardContent, CardDescription, CardTitle } from './ui/card'
+import { Card, CardContent, CardDescription } from './ui/card'
 import { BarChart3, Atom, AlertCircle, Lightbulb, ChevronDown, Check } from 'lucide-react'
 import { getSpeciesDisplayName } from './Plots/speciesFormat'
 import { useClickOutside } from '../hooks/useClickOutside'
@@ -719,12 +719,13 @@ export function SimulationChart({ results, metadata }) {
         </div>
 
         <div>
-          <CardTitle className="text-base xs:text-lg sm:text-xl">
-            Concentration Profiles (Log Scale)
-          </CardTitle>
           <CardDescription className="text-xs xs:text-sm">
-            {metadata?.mechanism?.toUpperCase()} mechanism •{metadata?.duration?.toLocaleString()}{' '}
-            seconds •{results.length} data points
+            {metadata?.mechanism?.toUpperCase()} {"\u00A0"}{"\u00A0"} mechanism
+            <br />
+            {metadata?.duration?.toLocaleString()}  seconds
+            {metadata?.duration != null && `   |   ${(metadata.duration / 3600).toFixed(2)}  hours`}
+            <br />
+            {results.length}&nbsp;&nbsp;data points
           </CardDescription>
         </div>
 

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -288,16 +288,16 @@ export function SimulationChart({ results, metadata }) {
         {/* Species Filter */}
         <div className="border rounded-lg p-2 xs:p-3 sm:p-4 bg-gray-50">
           <div className="flex flex-col xs:flex-row items-start xs:items-center justify-between gap-2 xs:gap-0 mb-3">
-            <div className="flex items-center gap-3 w-full xs:w-auto">
+            <div className="flex flex-wrap items-center justify-between gap-3 w-full">
               <div className="flex items-center border border-gray-300 rounded-lg divide-x divide-gray-300 bg-white">
                 <div className="relative" ref={selectAllMenuRef}>
                   <button
                     type="button"
                     onClick={() => setSelectAllMenuOpen((open) => !open)}
-                    className="flex items-center gap-1.5 text-gray-800 rounded-l-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                    className="flex items-center justify-between gap-1 w-32 h-8 text-gray-800 rounded-l-lg text-xs font-bold px-2 focus:outline-none focus:ring-2 focus:ring-blue-600"
                   >
                     {selectAllStatusLabel}
-                    <ChevronDown className="w-3.5 h-3.5" />
+                    <ChevronDown className="w-3.5 h-3.5 flex-shrink-0" />
                   </button>
 
                   {selectAllMenuOpen && (
@@ -342,23 +342,19 @@ export function SimulationChart({ results, metadata }) {
                   value={speciesSearch}
                   onChange={(e) => setSpeciesSearch(e.target.value)}
                   placeholder="Search species"
-                  className="flex-1 max-w-xs px-3 py-2 text-gray-800 placeholder:text-gray-400 rounded-r-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-600"
+                  className="w-[30rem] h-8 px-3 text-gray-800 placeholder:text-gray-400 rounded-r-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-600"
                 />
               </div>
-
-              <h4 className="font-semibold text-xs xs:text-sm text-gray-900">
-                ({displaySpecies.length} selected)
-              </h4>
 
               <div className="flex items-center border border-gray-300 rounded-lg divide-x divide-gray-300 bg-white">
                 <div className="relative" ref={plotUnitMenuRef}>
                   <button
                     type="button"
                     onClick={() => setPlotUnitMenuOpen((open) => !open)}
-                    className="flex items-center gap-1.5 text-gray-800 rounded-l-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                    className="flex items-center justify-between gap-1 w-24 h-8 text-gray-800 rounded-l-lg text-xs font-bold px-2 focus:outline-none focus:ring-2 focus:ring-blue-600"
                   >
                     {plotUnit.label}
-                    <ChevronDown className="w-3.5 h-3.5" />
+                    <ChevronDown className="w-3.5 h-3.5 flex-shrink-0" />
                   </button>
 
                   {plotUnitMenuOpen && (
@@ -395,10 +391,10 @@ export function SimulationChart({ results, metadata }) {
                   <button
                     type="button"
                     onClick={() => setTimeUnitMenuOpen((open) => !open)}
-                    className="flex items-center gap-1.5 text-gray-800 rounded-r-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                    className="flex items-center justify-between gap-1 w-24 h-8 text-gray-800 rounded-r-lg text-xs font-bold px-2 focus:outline-none focus:ring-2 focus:ring-blue-600"
                   >
                     {timeUnit.label}
-                    <ChevronDown className="w-3.5 h-3.5" />
+                    <ChevronDown className="w-3.5 h-3.5 flex-shrink-0" />
                   </button>
 
                   {timeUnitMenuOpen && (
@@ -428,7 +424,10 @@ export function SimulationChart({ results, metadata }) {
             </div>
           </div>
 
-          <div className="flex flex-wrap gap-1.5 xs:gap-2 max-h-32 overflow-y-auto">
+          <div className="flex flex-wrap items-center gap-1.5 xs:gap-2 max-h-32 overflow-y-auto">
+            <h4 className="font-semibold text-xs xs:text-sm text-gray-900 mr-1">
+              {displaySpecies.length} selected
+            </h4>
             {filteredSpecies.map((species) => (
               <button
                 key={species}

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -21,6 +21,14 @@ const TIME_UNITS = [
   { id: 'hours', label: 'Hours', axisLabel: 'Time (hr)', suffix: 'hr', divisor: 3600 },
 ]
 
+// Y-axis concentration unit options. Results are stored in mol/m^3 (the native
+// solver output); other units require a conversion function (e.g. ppb needs the
+// ideal gas law with per-point temperature/pressure) that isn't implemented yet.
+const PLOT_UNITS = [
+  { id: 'mol_m3', label: 'mol/m³', axisLabel: 'Concentration (mol m⁻³)', supported: true },
+  { id: 'ppb', label: 'ppb', axisLabel: 'Concentration (ppb)', supported: false },
+]
+
 // Round x up to the nearest "nice" number (1, 2, 5, or 10 times a power of 10)
 function niceNumber(x) {
   const exponent = Math.floor(Math.log10(x))
@@ -42,8 +50,10 @@ export function SimulationChart({ results, metadata }) {
   const [selectedSpecies, setSelectedSpecies] = useState([])
   const [initialized, setInitialized] = useState(false)
   const [timeUnitId, setTimeUnitId] = useState('seconds')
+  const [plotUnitId, setPlotUnitId] = useState('mol_m3')
 
   const timeUnit = TIME_UNITS.find((u) => u.id === timeUnitId) ?? TIME_UNITS[0]
+  const plotUnit = PLOT_UNITS.find((u) => u.id === plotUnitId) ?? PLOT_UNITS[0]
 
   // Color palette for species
   const colors = [
@@ -326,25 +336,42 @@ export function SimulationChart({ results, metadata }) {
           </div>
         </div>
 
-        {/* Time Unit Selector */}
-        <div className="flex items-center gap-2 xs:gap-3">
-          <h4 className="font-semibold text-xs xs:text-sm text-gray-900">Time Unit:</h4>
-          <div className="flex gap-1.5 xs:gap-2">
-            {TIME_UNITS.map((unit) => (
-              <Button
-                key={unit.id}
-                variant="ghost"
-                size="sm"
-                onClick={() => setTimeUnitId(unit.id)}
-                className={`rounded-lg text-xs font-bold ${
-                  timeUnitId === unit.id
-                    ? 'border border-border bg-transparent text-action'
-                    : 'bg-transparent text-muted hover:bg-surface-hover hover:text-ink'
-                }`}
-              >
-                {unit.label}
-              </Button>
-            ))}
+        {/* Plot Unit / Time Unit Selectors */}
+        <div className="flex flex-wrap items-center gap-4 xs:gap-6">
+          <div className="flex items-center gap-2 xs:gap-3">
+            <h4 className="font-semibold text-xs xs:text-sm text-gray-900">Plot Unit:</h4>
+            <select
+              value={plotUnitId}
+              onChange={(e) => setPlotUnitId(e.target.value)}
+              className="border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+            >
+              {PLOT_UNITS.map((unit) => (
+                <option
+                  key={unit.id}
+                  value={unit.id}
+                  disabled={!unit.supported}
+                  title={!unit.supported ? 'Conversion not yet supported' : undefined}
+                >
+                  {unit.label}
+                  {!unit.supported ? ' (coming soon)' : ''}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex items-center gap-2 xs:gap-3">
+            <h4 className="font-semibold text-xs xs:text-sm text-gray-900">Time Unit:</h4>
+            <select
+              value={timeUnitId}
+              onChange={(e) => setTimeUnitId(e.target.value)}
+              className="border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+            >
+              {TIME_UNITS.map((unit) => (
+                <option key={unit.id} value={unit.id}>
+                  {unit.label}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
 
@@ -501,7 +528,7 @@ export function SimulationChart({ results, metadata }) {
                 width={70}
               >
                 <Label
-                  value="Concentration (mol m-3)"
+                  value={plotUnit.axisLabel}
                   angle={-90}
                   position="insideLeft"
                   offset={10}

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -720,7 +720,11 @@ export function SimulationChart({ results, metadata }) {
 
         {/* Summary Box */}
         <div className="text-xs text-gray-600 bg-blue-50 border border-blue-200 rounded-lg p-3">
-          <CardDescription className="text-xs xs:text-sm">
+          <p className="font-semibold text-sm mb-1 flex items-center gap-2">
+            <BarChart3 className="w-4 h-4" />
+            Summary:
+          </p>
+          <CardDescription className="text-sm ml-4">
             • {metadata?.mechanism?.toUpperCase()}
             {metadata?.mechanism &&
               !metadata.mechanism.toLowerCase().includes('mechanism') && (
@@ -740,7 +744,7 @@ export function SimulationChart({ results, metadata }) {
         </div>
 
         {/* Info Box */}
-        <div className="text-xs text-gray-600 bg-blue-50 border border-blue-200 rounded-lg p-3">
+        <div className="text-xs text-gray-600 bg-gray-50 border border-gray-200 rounded-lg p-3">
           <p className="font-semibold mb-1 flex items-center gap-2">
             <Lightbulb className="w-4 h-4" />
             Chart Controls:

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -11,7 +11,6 @@ import {
   Label,
 } from 'recharts'
 import { Card, CardContent, CardDescription, CardTitle } from './ui/card'
-import { Button } from './ui/button'
 import { BarChart3, Atom, AlertCircle, Lightbulb, ChevronDown, Check } from 'lucide-react'
 import { getSpeciesDisplayName } from './Plots/speciesFormat'
 import { useClickOutside } from '../hooks/useClickOutside'
@@ -54,16 +53,20 @@ export function SimulationChart({ results, metadata }) {
   const [plotUnitId, setPlotUnitId] = useState('mol_m3')
   const [plotUnitMenuOpen, setPlotUnitMenuOpen] = useState(false)
   const [timeUnitMenuOpen, setTimeUnitMenuOpen] = useState(false)
+  const [selectAllMenuOpen, setSelectAllMenuOpen] = useState(false)
   const plotUnitMenuRef = useRef(null)
   const timeUnitMenuRef = useRef(null)
+  const selectAllMenuRef = useRef(null)
 
   const timeUnit = TIME_UNITS.find((u) => u.id === timeUnitId) ?? TIME_UNITS[0]
   const plotUnit = PLOT_UNITS.find((u) => u.id === plotUnitId) ?? PLOT_UNITS[0]
 
   const closePlotUnitMenu = useCallback(() => setPlotUnitMenuOpen(false), [])
   const closeTimeUnitMenu = useCallback(() => setTimeUnitMenuOpen(false), [])
+  const closeSelectAllMenu = useCallback(() => setSelectAllMenuOpen(false), [])
   useClickOutside(plotUnitMenuRef, closePlotUnitMenu, plotUnitMenuOpen)
   useClickOutside(timeUnitMenuRef, closeTimeUnitMenu, timeUnitMenuOpen)
+  useClickOutside(selectAllMenuRef, closeSelectAllMenu, selectAllMenuOpen)
 
   // Color palette for species
   const colors = [
@@ -214,6 +217,11 @@ export function SimulationChart({ results, metadata }) {
   const allFilteredSelected =
     filteredSpecies.length > 0 && filteredSpecies.every((sp) => displaySpecies.includes(sp))
   const noneSelected = displaySpecies.length === 0
+  const selectAllStatusLabel = allFilteredSelected
+    ? 'All selected'
+    : noneSelected
+      ? 'None selected'
+      : 'Selection'
 
   // Validation checks
   if (!results || results.length === 0) {
@@ -281,36 +289,140 @@ export function SimulationChart({ results, metadata }) {
         <div className="border rounded-lg p-2 xs:p-3 sm:p-4 bg-gray-50">
           <div className="flex flex-col xs:flex-row items-start xs:items-center justify-between gap-2 xs:gap-0 mb-3">
             <div className="flex items-center gap-3 w-full xs:w-auto">
-              <h4 className="font-semibold text-xs xs:text-sm text-gray-900 mr-4">
+              <div className="relative" ref={selectAllMenuRef}>
+                <button
+                  type="button"
+                  onClick={() => setSelectAllMenuOpen((open) => !open)}
+                  className="flex items-center gap-1.5 border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                >
+                  {selectAllStatusLabel}
+                  <ChevronDown className="w-3.5 h-3.5" />
+                </button>
+
+                {selectAllMenuOpen && (
+                  <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSelectedSpecies(filteredSpecies)
+                        setSelectAllMenuOpen(false)
+                      }}
+                      className="w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 text-gray-800 hover:bg-gray-100"
+                    >
+                      <Check
+                        className={`w-3.5 h-3.5 flex-shrink-0 ${
+                          allFilteredSelected ? 'opacity-100' : 'opacity-0'
+                        }`}
+                      />
+                      Select all
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setSelectedSpecies([])
+                        setSelectAllMenuOpen(false)
+                      }}
+                      className="w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 text-gray-800 hover:bg-gray-100"
+                    >
+                      <Check
+                        className={`w-3.5 h-3.5 flex-shrink-0 ${
+                          noneSelected ? 'opacity-100' : 'opacity-0'
+                        }`}
+                      />
+                      Deselect all
+                    </button>
+                  </div>
+                )}
+              </div>
+
+              {/* Search bar for species filter */}
+              <input
+                type="text"
+                value={speciesSearch}
+                onChange={(e) => setSpeciesSearch(e.target.value)}
+                placeholder="Search species"
+                className="flex-1 max-w-xs px-3 py-2 border-2 border-gray-300 bg-white text-gray-800 placeholder:text-gray-400 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-600"
+              />
+
+              <h4 className="font-semibold text-xs xs:text-sm text-gray-900">
                 ({displaySpecies.length} selected)
               </h4>
-              <Button
-                variant={allFilteredSelected ? 'assist' : 'outline'}
-                size="sm"
-                onClick={() => setSelectedSpecies(filteredSpecies)}
-                className="rounded-lg text-xs font-bold"
-              >
-                Select All
-              </Button>
-              <Button
-                variant={noneSelected ? 'assist' : 'outline'}
-                size="sm"
-                onClick={() => setSelectedSpecies([])}
-                className="rounded-lg text-xs font-bold"
-              >
-                Deselect All
-              </Button>
+
+              <div className="relative" ref={plotUnitMenuRef}>
+                <button
+                  type="button"
+                  onClick={() => setPlotUnitMenuOpen((open) => !open)}
+                  className="flex items-center gap-1.5 border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                >
+                  {plotUnit.label}
+                  <ChevronDown className="w-3.5 h-3.5" />
+                </button>
+
+                {plotUnitMenuOpen && (
+                  <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
+                    {PLOT_UNITS.map((unit) => (
+                      <button
+                        key={unit.id}
+                        type="button"
+                        disabled={!unit.supported}
+                        title={!unit.supported ? 'Conversion not yet supported' : undefined}
+                        onClick={() => {
+                          setPlotUnitId(unit.id)
+                          setPlotUnitMenuOpen(false)
+                        }}
+                        className={`w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 ${
+                          unit.supported
+                            ? 'text-gray-800 hover:bg-gray-100'
+                            : 'text-gray-400 cursor-not-allowed'
+                        }`}
+                      >
+                        <Check
+                          className={`w-3.5 h-3.5 flex-shrink-0 ${
+                            plotUnitId === unit.id ? 'opacity-100' : 'opacity-0'
+                          }`}
+                        />
+                        {unit.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div className="relative" ref={timeUnitMenuRef}>
+                <button
+                  type="button"
+                  onClick={() => setTimeUnitMenuOpen((open) => !open)}
+                  className="flex items-center gap-1.5 border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                >
+                  {timeUnit.label}
+                  <ChevronDown className="w-3.5 h-3.5" />
+                </button>
+
+                {timeUnitMenuOpen && (
+                  <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
+                    {TIME_UNITS.map((unit) => (
+                      <button
+                        key={unit.id}
+                        type="button"
+                        onClick={() => {
+                          setTimeUnitId(unit.id)
+                          setTimeUnitMenuOpen(false)
+                        }}
+                        className="w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 text-gray-800 hover:bg-gray-100"
+                      >
+                        <Check
+                          className={`w-3.5 h-3.5 flex-shrink-0 ${
+                            timeUnitId === unit.id ? 'opacity-100' : 'opacity-0'
+                          }`}
+                        />
+                        {unit.label}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
           </div>
-
-          {/* Search bar for species filter */}
-          <input
-            type="text"
-            value={speciesSearch}
-            onChange={(e) => setSpeciesSearch(e.target.value)}
-            placeholder="Search species"
-            className="w-1/2 mb-3 px-3 py-2 border-2 border-gray-300 bg-white text-gray-800 placeholder:text-gray-400 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-600"
-          />
 
           <div className="flex flex-wrap gap-1.5 xs:gap-2 max-h-32 overflow-y-auto">
             {filteredSpecies.map((species) => (
@@ -331,83 +443,6 @@ export function SimulationChart({ results, metadata }) {
                 {getSpeciesDisplayName(species)}
               </button>
             ))}
-          </div>
-        </div>
-
-        {/* Plot Unit / Time Unit Selectors */}
-        <div className="flex flex-wrap items-center gap-4 xs:gap-6">
-          <div className="relative" ref={plotUnitMenuRef}>
-            <button
-              type="button"
-              onClick={() => setPlotUnitMenuOpen((open) => !open)}
-              className="flex items-center gap-1.5 border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
-            >
-              {plotUnit.label}
-              <ChevronDown className="w-3.5 h-3.5" />
-            </button>
-
-            {plotUnitMenuOpen && (
-              <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
-                {PLOT_UNITS.map((unit) => (
-                  <button
-                    key={unit.id}
-                    type="button"
-                    disabled={!unit.supported}
-                    title={!unit.supported ? 'Conversion not yet supported' : undefined}
-                    onClick={() => {
-                      setPlotUnitId(unit.id)
-                      setPlotUnitMenuOpen(false)
-                    }}
-                    className={`w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 ${
-                      unit.supported
-                        ? 'text-gray-800 hover:bg-gray-100'
-                        : 'text-gray-400 cursor-not-allowed'
-                    }`}
-                  >
-                    <Check
-                      className={`w-3.5 h-3.5 flex-shrink-0 ${
-                        plotUnitId === unit.id ? 'opacity-100' : 'opacity-0'
-                      }`}
-                    />
-                    {unit.label}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-
-          <div className="relative" ref={timeUnitMenuRef}>
-            <button
-              type="button"
-              onClick={() => setTimeUnitMenuOpen((open) => !open)}
-              className="flex items-center gap-1.5 border border-gray-300 bg-white text-gray-800 rounded-lg text-xs font-bold px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-600"
-            >
-              {timeUnit.label}
-              <ChevronDown className="w-3.5 h-3.5" />
-            </button>
-
-            {timeUnitMenuOpen && (
-              <div className="absolute z-10 mt-1 min-w-[9rem] bg-white border border-gray-300 rounded-lg shadow-lg py-1">
-                {TIME_UNITS.map((unit) => (
-                  <button
-                    key={unit.id}
-                    type="button"
-                    onClick={() => {
-                      setTimeUnitId(unit.id)
-                      setTimeUnitMenuOpen(false)
-                    }}
-                    className="w-full flex items-center gap-2 text-left text-xs font-bold px-3 py-1.5 text-gray-800 hover:bg-gray-100"
-                  >
-                    <Check
-                      className={`w-3.5 h-3.5 flex-shrink-0 ${
-                        timeUnitId === unit.id ? 'opacity-100' : 'opacity-0'
-                      }`}
-                    />
-                    {unit.label}
-                  </button>
-                ))}
-              </div>
-            )}
           </div>
         </div>
 

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -10,26 +10,24 @@ import {
   ResponsiveContainer,
   Label,
 } from 'recharts'
-import { Card, CardContent, CardDescription } from './ui/card'
 import { BarChart3, Atom, AlertCircle, Lightbulb, ChevronDown, Check } from 'lucide-react'
+import { Card, CardContent, CardDescription } from './ui/card'
 import { getSpeciesDisplayName } from './Plots/speciesFormat'
 import { useClickOutside } from '../hooks/useClickOutside'
 
-// X-axis time unit options: seconds are converted by dividing by `divisor`
+// X-axis time unit options
 const TIME_UNITS = [
   { id: 'seconds', label: 'Seconds', axisLabel: 'Time (s)', suffix: 's', divisor: 1 },
   { id: 'hours', label: 'Hours', axisLabel: 'Time (hr)', suffix: 'hr', divisor: 3600 },
 ]
 
-// Y-axis concentration unit options. Results are stored in mol/m^3 (the native
-// solver output); other units require a conversion function (e.g. ppb needs the
-// ideal gas law with per-point temperature/pressure) that isn't implemented yet.
+// Y-axis concentration unit options
 const PLOT_UNITS = [
   { id: 'mol_m3', label: 'mol m-3', axisLabel: 'Concentration (mol m-3)', supported: true },
   { id: 'ppb', label: 'ppb', axisLabel: 'Concentration (ppb)', supported: false },
 ]
 
-// Round x up to the nearest "nice" number (1, 2, 5, or 10 times a power of 10)
+// Round a value up to a human-friendly scale (1, 2, 5, or 10 times a power of 10)
 function niceNumber(x) {
   const exponent = Math.floor(Math.log10(x))
   const fraction = x / 10 ** exponent
@@ -154,8 +152,9 @@ export function SimulationChart({ results, metadata }) {
     })
   }, [results, allSpecies, timeUnit.divisor])
 
-  // Fixed-percentage padding so the axis bounds stay visually consistent across time units
-  // (Recharts' 'auto' domain picks "nice" round numbers whose padding ratio varies with magnitude)
+  // Keep axis bounds visually consistent across time units.
+  // Recharts' "auto" domain varies padding based on magnitude.
+
   const timeDomain = useMemo(() => {
     const times = chartData.map((point) => point.timeSeconds).filter((t) => isFinite(t))
     if (times.length === 0) return [0, 1]
@@ -168,10 +167,7 @@ export function SimulationChart({ results, metadata }) {
     return [Math.max(0, minTime - padding), maxTime + padding]
   }, [chartData])
 
-  // For Hours, pick a "nice" step (always a multiple of 0.5 hr) that yields roughly
-  // TARGET_HOUR_TICKS gridlines regardless of simulation length, instead of always
-  // stepping by 0.5 hr (which gets cluttered on long runs) or Recharts' auto step
-  // (which picks arbitrary, non-0.5-hr-aligned values).
+  // Use a reader-friendly step (in 0.5-hour increments) for gridlines.
   const HOUR_TICK_STEP = 0.5
   const TARGET_HOUR_TICKS = 5
   const xAxisTicks = useMemo(() => {
@@ -218,10 +214,10 @@ export function SimulationChart({ results, metadata }) {
     filteredSpecies.length > 0 && filteredSpecies.every((sp) => displaySpecies.includes(sp))
   const noneSelected = displaySpecies.length === 0
   const selectAllStatusLabel = allFilteredSelected
-    ? 'All selected'
+    ? 'Select all'
     : noneSelected
-      ? 'None selected'
-      : 'Selection'
+      ? 'Deselect all'
+      : 'Custom'
 
   // Validation checks
   if (!results || results.length === 0) {

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -15,6 +15,13 @@ import { Button } from './ui/button'
 import { BarChart3, Atom, AlertCircle, Lightbulb } from 'lucide-react'
 import { getSpeciesDisplayName } from './Plots/speciesFormat'
 
+// X-axis time unit options: seconds are converted by dividing by `divisor`
+const TIME_UNITS = [
+  { id: 'seconds', label: 'Seconds', axisLabel: 'Time (s)', suffix: 's', divisor: 1 },
+  { id: 'minutes', label: 'Minutes', axisLabel: 'Time (min)', suffix: 'min', divisor: 60 },
+  { id: 'hours', label: 'Hours', axisLabel: 'Time (hr)', suffix: 'hr', divisor: 3600 },
+]
+
 /**
  * SimulationChart Component
  * Displays atmospheric chemistry concentration data with interactive controls
@@ -27,6 +34,9 @@ export function SimulationChart({ results, metadata }) {
   const [speciesSearch, setSpeciesSearch] = useState('')
   const [selectedSpecies, setSelectedSpecies] = useState([])
   const [initialized, setInitialized] = useState(false)
+  const [timeUnitId, setTimeUnitId] = useState('seconds')
+
+  const timeUnit = TIME_UNITS.find((u) => u.id === timeUnitId) ?? TIME_UNITS[0]
 
   // Color palette for species
   const colors = [
@@ -86,7 +96,7 @@ export function SimulationChart({ results, metadata }) {
     return results.map((result) => {
       const time = result.time ?? result.timestamp ?? result.date ?? 0
       const point = {
-        timeSeconds: time,
+        timeSeconds: time / timeUnit.divisor,
       }
 
       const source =
@@ -112,7 +122,7 @@ export function SimulationChart({ results, metadata }) {
 
       return point
     })
-  }, [results, allSpecies])
+  }, [results, allSpecies, timeUnit.divisor])
 
   // Toggle species selection
   const toggleSpecies = (species) => {
@@ -128,10 +138,10 @@ export function SimulationChart({ results, metadata }) {
     const search = speciesSearch.trim().toLowerCase()
     if (!search) return allSpecies
     return allSpecies
-      .filter((sp) => sp.toLowerCase().includes(search))
+      .filter((sp) => getSpeciesDisplayName(sp).toLowerCase().includes(search))
       .sort((a, b) => {
-        const aExact = a.toLowerCase() === search
-        const bExact = b.toLowerCase() === search
+        const aExact = getSpeciesDisplayName(a).toLowerCase() === search
+        const bExact = getSpeciesDisplayName(b).toLowerCase() === search
         if (aExact && !bExact) return -1
         if (!aExact && bExact) return 1
         return 0
@@ -273,6 +283,28 @@ export function SimulationChart({ results, metadata }) {
           </div>
         </div>
 
+        {/* Time Unit Selector */}
+        <div className="flex items-center gap-2 xs:gap-3">
+          <h4 className="font-semibold text-xs xs:text-sm text-gray-900">Time Unit:</h4>
+          <div className="flex gap-1.5 xs:gap-2">
+            {TIME_UNITS.map((unit) => (
+              <Button
+                key={unit.id}
+                variant="ghost"
+                size="sm"
+                onClick={() => setTimeUnitId(unit.id)}
+                className={`rounded-lg text-xs font-bold ${
+                  timeUnitId === unit.id
+                    ? 'border border-border bg-transparent text-action'
+                    : 'bg-transparent text-muted hover:bg-surface-hover hover:text-ink'
+                }`}
+              >
+                {unit.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+
         {/* Chart */}
         <div className="border rounded-lg p-2 xs:p-3 sm:p-4 bg-white">
           <ResponsiveContainer width="100%" height={400} className="xs:hidden">
@@ -287,7 +319,7 @@ export function SimulationChart({ results, metadata }) {
                 type="number"
               >
                 <Label
-                  value="Time (s)"
+                  value={timeUnit.axisLabel}
                   position="insideBottom"
                   offset={-5}
                   style={{ fill: '#1f2937', fontWeight: 600, fontSize: 11 }}
@@ -323,7 +355,8 @@ export function SimulationChart({ results, metadata }) {
                         className="font-semibold mb-1 text-xs text-gray-900"
                         style={{ color: '#111827' }}
                       >
-                        Time: {label?.toLocaleString()} s
+                        Time: {timeUnit.divisor === 1 ? label?.toLocaleString() : label?.toFixed(2)}{' '}
+                        {timeUnit.suffix}
                       </p>
                       <div className="space-y-0.5">
                         {payload.map((entry, idx) => {
@@ -400,7 +433,7 @@ export function SimulationChart({ results, metadata }) {
                 type="number"
               >
                 <Label
-                  value="Time (seconds)"
+                  value={timeUnit.axisLabel}
                   position="insideBottom"
                   offset={-5}
                   style={{ fill: '#1f2937', fontWeight: 600, fontSize: 14 }}
@@ -444,7 +477,8 @@ export function SimulationChart({ results, metadata }) {
                         className="font-semibold mb-2 text-sm text-gray-900"
                         style={{ color: '#111827' }}
                       >
-                        Time: {label?.toLocaleString()} seconds
+                        Time: {timeUnit.divisor === 1 ? label?.toLocaleString() : label?.toFixed(2)}{' '}
+                        {timeUnit.label.toLowerCase()}
                       </p>
                       <div className="space-y-1">
                         {payload.map((entry, idx) => {

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -501,7 +501,7 @@ export function SimulationChart({ results, metadata }) {
                 width={70}
               >
                 <Label
-                  value="Concentration (mol mol⁻¹)"
+                  value="Concentration (mol m-3)"
                   angle={-90}
                   position="insideLeft"
                   offset={10}

--- a/src/components/SimulationChart.jsx
+++ b/src/components/SimulationChart.jsx
@@ -282,7 +282,7 @@ export function SimulationChart({ results, metadata }) {
           <div className="flex flex-col xs:flex-row items-start xs:items-center justify-between gap-2 xs:gap-0 mb-3">
             <div className="flex items-center gap-3 w-full xs:w-auto">
               <h4 className="font-semibold text-xs xs:text-sm text-gray-900 mr-4">
-                Species Filter ({displaySpecies.length} selected)
+                ({displaySpecies.length} selected)
               </h4>
               <Button
                 variant={allFilteredSelected ? 'assist' : 'outline'}
@@ -309,7 +309,7 @@ export function SimulationChart({ results, metadata }) {
             value={speciesSearch}
             onChange={(e) => setSpeciesSearch(e.target.value)}
             placeholder="Search species"
-            className="w-full mb-3 px-3 py-2 border-2 border-gray-300 bg-white text-gray-800 placeholder:text-gray-400 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-600"
+            className="w-1/2 mb-3 px-3 py-2 border-2 border-gray-300 bg-white text-gray-800 placeholder:text-gray-400 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-600"
           />
 
           <div className="flex flex-wrap gap-1.5 xs:gap-2 max-h-32 overflow-y-auto">

--- a/src/components/pages/MusicBoxAppNew.jsx
+++ b/src/components/pages/MusicBoxAppNew.jsx
@@ -61,7 +61,7 @@ function AppContent({ onNavigate }) {
       {/* Main content area with responsive left margin for sidebar */}
       <div className="min-h-screen relative z-10 lg:ml-64 transition-all duration-300">
         {/* Responsive container with proper padding for mobile */}
-        <div className="container mx-auto px-2 xs:px-3 sm:px-6 lg:px-8 py-3 xs:py-4 sm:py-6 lg:py-8 pt-14 xs:pt-16 lg:pt-6">
+        <div className="max-w-7xl mx-auto px-2 xs:px-3 sm:px-6 lg:px-8 py-3 xs:py-4 sm:py-6 lg:py-8 pt-14 xs:pt-16 lg:pt-6">
           <Routes>
             <Route path="/" element={<DashboardPage />} />
             <Route path="/guide" element={<GuidePage />} />

--- a/src/hooks/useClickOutside.js
+++ b/src/hooks/useClickOutside.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 
-// Calls onOutsideClick when a mousedown happens outside the element ref points to.
-// Pass `active` to only attach the listener while something (a dropdown) is open.
+// Calls onOutsideClick when mousedown occurs outside the element.
+// Only attaches the listener when active (e.g., when a dropdown is open).
 export function useClickOutside(ref, onOutsideClick, active = true) {
   useEffect(() => {
     if (!active) return

--- a/src/hooks/useClickOutside.js
+++ b/src/hooks/useClickOutside.js
@@ -1,0 +1,18 @@
+import { useEffect } from 'react'
+
+// Calls onOutsideClick when a mousedown happens outside the element ref points to.
+// Pass `active` to only attach the listener while something (e.g. a dropdown) is open.
+export function useClickOutside(ref, onOutsideClick, active = true) {
+  useEffect(() => {
+    if (!active) return
+
+    const handleClick = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        onOutsideClick()
+      }
+    }
+
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [ref, onOutsideClick, active])
+}

--- a/src/hooks/useClickOutside.js
+++ b/src/hooks/useClickOutside.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 
 // Calls onOutsideClick when a mousedown happens outside the element ref points to.
-// Pass `active` to only attach the listener while something (e.g. a dropdown) is open.
+// Pass `active` to only attach the listener while something (a dropdown) is open.
 export function useClickOutside(ref, onOutsideClick, active = true) {
   useEffect(() => {
     if (!active) return


### PR DESCRIPTION
This PR:
- Keeps the main content area centered horizontally with a maximum width of 1280px.
- Adds a option to choose time unit (seconds | hours), and concentration units in Y axis (mol m-3 | ppb - disabled)
- Keeps axis bounds visually consistent across time units.
- Fixes a bug in search species with name
- Moves the metadata below the simulation chart.
- Improves the layout of the species selection, search bar, and unit selection options.
- Addresses most of the issues listed in #553.