### PR TITLE
Recover molecular weight

### DIFF
--- a/__tests__/RunSimulationButton.analytical.test.jsx
+++ b/__tests__/RunSimulationButton.analytical.test.jsx
@@ -13,6 +13,7 @@ import { vi } from 'vitest';
 import analyticalConfig from '@ncar/music-box/examples/analytical/my_config.json' with { type: 'json' };
 import analyticalInitialConditionsCsv from '@ncar/music-box/examples/analytical/initial_conditions.csv?raw';
 import { parseCsvToBlock } from '@ncar/music-box';
+import { durationSeconds, stepSeconds } from './helpers/boxModelOptions';
 
 function withInlineConditionData(config, csvContents = []) {
   const existingData = Array.isArray(config?.conditions?.data) ? config.conditions.data : [];
@@ -27,16 +28,6 @@ function withInlineConditionData(config, csvContents = []) {
     },
   };
 }
-
-// Mock MusicBox to avoid actual computation
-vi.mock('@ncar/music-box', () => ({
-  parseCsvToBlock: vi.fn((...args) => args[0]), // simple passthrough for test
-  MusicBox: {
-    fromJson: vi.fn().mockReturnValue({
-      solve: vi.fn().mockResolvedValue([{ time: 0, concentrations: { O3: 1 } }]),
-    }),
-  },
-}));
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -75,7 +66,7 @@ describe('RunSimulationButton (Analytical example)', () => {
     (analyticalExample.mechanism.mechanism.species || []).forEach((species) => {
       store.dispatch(addSpecies({
         name: species.name,
-        molecular_weight_kg_mol: 0.048,
+        molecular_weight_kg_mol: species['molecular weight [kg mol-1]'],
         properties: {},
       }));
     });
@@ -83,9 +74,9 @@ describe('RunSimulationButton (Analytical example)', () => {
       store.dispatch(addReaction({ ...reaction, id: reaction.id || 'test' }));
     });
     const options = analyticalExample.mechanism["box model options"] || {};
-    if (options["simulation length [sec]"]) store.dispatch(setDuration(options["simulation length [sec]"]));
-    if (options["chemistry time step [sec]"]) store.dispatch(setTimeStep(options["chemistry time step [sec]"]));
-    if (options["output time step [sec]"]) store.dispatch(setOutputFrequency(options["output time step [sec]"]));
+    store.dispatch(setDuration(durationSeconds(options)));
+    store.dispatch(setTimeStep(stepSeconds(options, "chemistry time step")));
+    store.dispatch(setOutputFrequency(stepSeconds(options, "output time step")));
     store.dispatch(setConditions(analyticalExample.mechanism.conditions));
     store.dispatch(setExampleFiles({ ...analyticalExample.csv, data: analyticalExample.mechanism.conditions?.data || [] }));
     store.dispatch(setExampleLoaded(false));

--- a/__tests__/RunSimulationButton.carbon-bond-5.test.jsx
+++ b/__tests__/RunSimulationButton.carbon-bond-5.test.jsx
@@ -14,6 +14,7 @@ import carbonBond5Config from '@ncar/music-box/examples/carbon_bond_5/my_config.
 import carbonBond5InitialConcentrationsCsv from '@ncar/music-box/examples/carbon_bond_5/initial_concentrations.csv?raw';
 import carbonBond5InitialReactionRatesCsv from '@ncar/music-box/examples/carbon_bond_5/initial_reaction_rates.csv?raw';
 import { parseCsvToBlock } from '@ncar/music-box';
+import { durationSeconds, stepSeconds } from './helpers/boxModelOptions';
 
 function withInlineConditionData(config, csvContents = []) {
   const existingData = Array.isArray(config?.conditions?.data) ? config.conditions.data : [];
@@ -28,16 +29,6 @@ function withInlineConditionData(config, csvContents = []) {
     },
   };
 }
-
-// Mock MusicBox to avoid actual computation
-vi.mock('@ncar/music-box', () => ({
-  parseCsvToBlock: vi.fn((...args) => args[0]), // simple passthrough for test
-  MusicBox: {
-    fromJson: vi.fn().mockReturnValue({
-      solve: vi.fn().mockResolvedValue([{ time: 0, concentrations: { O3: 1 } }]),
-    }),
-  },
-}));
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -76,7 +67,7 @@ describe('RunSimulationButton (Carbon-Bond-5 example)', () => {
     (carbonBond5Example.mechanism.mechanism.species || []).forEach((species) => {
       store.dispatch(addSpecies({
         name: species.name,
-        molecular_weight_kg_mol: 0.048,
+        molecular_weight_kg_mol: species['molecular weight [kg mol-1]'],
         properties: {},
       }));
     });
@@ -84,9 +75,9 @@ describe('RunSimulationButton (Carbon-Bond-5 example)', () => {
       store.dispatch(addReaction({ ...reaction, id: reaction.id || 'test' }));
     });
     const options = carbonBond5Example.mechanism["box model options"] || {};
-    if (options["simulation length [sec]"]) store.dispatch(setDuration(options["simulation length [sec]"]));
-    if (options["chemistry time step [sec]"]) store.dispatch(setTimeStep(options["chemistry time step [sec]"]));
-    if (options["output time step [sec]"]) store.dispatch(setOutputFrequency(options["output time step [sec]"]));
+    store.dispatch(setDuration(durationSeconds(options)));
+    store.dispatch(setTimeStep(stepSeconds(options, "chemistry time step")));
+    store.dispatch(setOutputFrequency(stepSeconds(options, "output time step")));
     store.dispatch(setConditions(carbonBond5Example.mechanism.conditions));
     store.dispatch(setExampleFiles({ ...carbonBond5Example.csv, data: carbonBond5Example.mechanism.conditions?.data || [] }));
     store.dispatch(setExampleLoaded(false));

--- a/__tests__/RunSimulationButton.chapman.test.jsx
+++ b/__tests__/RunSimulationButton.chapman.test.jsx
@@ -13,6 +13,7 @@ import chapmanConfig from '@ncar/music-box/examples/chapman/my_config.json' with
 import chapmanInitialConcentrationsCsv from '@ncar/music-box/examples/chapman/initial_concentrations.csv?raw';
 import chapmanConditionsBoulderCsv from '@ncar/music-box/examples/chapman/conditions_Boulder.csv?raw';
 import { parseCsvToBlock } from '@ncar/music-box';
+import { durationSeconds, stepSeconds } from './helpers/boxModelOptions';
 
 // Helper to build the same data structure as ExampleLoader
 function toExampleCsvJson(content) {
@@ -55,17 +56,7 @@ const chapmanExample = {
   mechanism: withInlineConditionData(chapmanConfig, [chapmanInitialConcentrationsCsv, chapmanConditionsBoulderCsv]),
 };
 
-// Mock MusicBox to avoid actual computation
 import { vi } from 'vitest';
-
-vi.mock('@ncar/music-box', () => ({
-  parseCsvToBlock: vi.fn((...args) => args[0]), // simple passthrough for test
-  MusicBox: {
-    fromJson: vi.fn().mockReturnValue({
-      solve: vi.fn().mockResolvedValue([{ time: 0, concentrations: { O3: 1 } }]),
-    }),
-  },
-}));
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -99,7 +90,7 @@ describe('RunSimulationButton (Chapman example)', () => {
     (chapmanExample.mechanism.mechanism.species || []).forEach((species) => {
       store.dispatch(addSpecies({
         name: species.name,
-        molecular_weight_kg_mol: 0.048,
+        molecular_weight_kg_mol: species['molecular weight [kg mol-1]'],
         properties: {},
       }));
     });
@@ -109,9 +100,9 @@ describe('RunSimulationButton (Chapman example)', () => {
     });
     // Set box model options
     const options = chapmanExample.mechanism["box model options"] || {};
-    if (options["simulation length [sec]"]) store.dispatch(setDuration(options["simulation length [sec]"]));
-    if (options["chemistry time step [sec]"]) store.dispatch(setTimeStep(options["chemistry time step [sec]"]));
-    if (options["output time step [sec]"]) store.dispatch(setOutputFrequency(options["output time step [sec]"]));
+    store.dispatch(setDuration(durationSeconds(options)));
+    store.dispatch(setTimeStep(stepSeconds(options, "chemistry time step")));
+    store.dispatch(setOutputFrequency(stepSeconds(options, "output time step")));
     store.dispatch(setConditions(chapmanExample.mechanism.conditions));
     store.dispatch(setExampleFiles({ ...chapmanExample.csv, data: chapmanExample.mechanism.conditions?.data || [] }));
     store.dispatch(setExampleLoaded(false));

--- a/__tests__/RunSimulationButton.flow-tube.test.jsx
+++ b/__tests__/RunSimulationButton.flow-tube.test.jsx
@@ -7,13 +7,13 @@ import simulationReducer from '../src/redux/slices/simulationSlice';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 
 import { RunSimulationButton } from '../src/components/RunSimulationButton';
-import { vi } from 'vitest';
 
 // Flow-Tube Example Imports
 import flowTubeConfig from '@ncar/music-box/examples/flow_tube/my_config.json' with { type: 'json' };
 import flowTubeInitialConcentrationsCsv from '@ncar/music-box/examples/flow_tube/initial_concentrations.csv?raw';
 import flowTubeInitialReactionRatesCsv from '@ncar/music-box/examples/flow_tube/initial_reaction_rates.csv?raw';
 import { parseCsvToBlock } from '@ncar/music-box';
+import { durationSeconds, stepSeconds } from './helpers/boxModelOptions';
 
 function withInlineConditionData(config, csvContents = []) {
   const existingData = Array.isArray(config?.conditions?.data) ? config.conditions.data : [];
@@ -29,15 +29,7 @@ function withInlineConditionData(config, csvContents = []) {
   };
 }
 
-// Mock MusicBox to avoid actual computation
-vi.mock('@ncar/music-box', () => ({
-  parseCsvToBlock: vi.fn((...args) => args[0]), // simple passthrough for test
-  MusicBox: {
-    fromJson: vi.fn().mockReturnValue({
-      solve: vi.fn().mockResolvedValue([{ time: 0, concentrations: { O3: 1 } }]),
-    }),
-  },
-}));
+import { vi } from 'vitest';
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -76,7 +68,7 @@ describe('RunSimulationButton (Flow-Tube example)', () => {
     (flowTubeExample.mechanism.mechanism.species || []).forEach((species) => {
       store.dispatch(addSpecies({
         name: species.name,
-        molecular_weight_kg_mol: 0.048,
+        molecular_weight_kg_mol: species['molecular weight [kg mol-1]'],
         properties: {},
       }));
     });
@@ -84,9 +76,9 @@ describe('RunSimulationButton (Flow-Tube example)', () => {
       store.dispatch(addReaction({ ...reaction, id: reaction.id || 'test' }));
     });
     const options = flowTubeExample.mechanism["box model options"] || {};
-    if (options["simulation length [sec]"]) store.dispatch(setDuration(options["simulation length [sec]"]));
-    if (options["chemistry time step [sec]"]) store.dispatch(setTimeStep(options["chemistry time step [sec]"]));
-    if (options["output time step [sec]"]) store.dispatch(setOutputFrequency(options["output time step [sec]"]));
+    store.dispatch(setDuration(durationSeconds(options)));
+    store.dispatch(setTimeStep(stepSeconds(options, "chemistry time step")));
+    store.dispatch(setOutputFrequency(stepSeconds(options, "output time step")));
     store.dispatch(setConditions(flowTubeExample.mechanism.conditions));
     store.dispatch(setExampleFiles({ ...flowTubeExample.csv, data: flowTubeExample.mechanism.conditions?.data || [] }));
     store.dispatch(setExampleLoaded(false));

--- a/__tests__/RunSimulationButton.ts1.test.jsx
+++ b/__tests__/RunSimulationButton.ts1.test.jsx
@@ -7,12 +7,12 @@ import simulationReducer from '../src/redux/slices/simulationSlice';
 import { render, fireEvent, waitFor, screen } from '@testing-library/react';
 
 import { RunSimulationButton } from '../src/components/RunSimulationButton';
-import { vi } from 'vitest';
 
 // TS1 Example Imports
 import ts1Config from '@ncar/music-box/examples/ts1/my_config.json' with { type: 'json' };
 import ts1InitialConditionsCsv from '@ncar/music-box/examples/ts1/initial_conditions.csv?raw';
 import { parseCsvToBlock } from '@ncar/music-box';
+import { durationSeconds, stepSeconds } from './helpers/boxModelOptions';
 
 function withInlineConditionData(config, csvContents = []) {
   const existingData = Array.isArray(config?.conditions?.data) ? config.conditions.data : [];
@@ -28,15 +28,11 @@ function withInlineConditionData(config, csvContents = []) {
   };
 }
 
-// Mock MusicBox to avoid actual computation
-vi.mock('@ncar/music-box', () => ({
-  parseCsvToBlock: vi.fn((...args) => args[0]), // simple passthrough for test
-  MusicBox: {
-    fromJson: vi.fn().mockReturnValue({
-      solve: vi.fn().mockResolvedValue([{ time: 0, concentrations: { O3: 1 } }]),
-    }),
-  },
-}));
+// TS1 is the only bundled mechanism with SURFACE reactions, so it is the only one that
+// exercises tracer injection into 'gas-phase products' and the molecular-weight requirement
+// that comes with it. A real solve is slow. See solverPayloadContract.test.js for the cheap
+// schema-only coverage.
+import { vi } from 'vitest';
 
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
@@ -75,7 +71,7 @@ describe('RunSimulationButton (TS1 example)', () => {
     (ts1Example.mechanism.mechanism.species || []).forEach((species) => {
       store.dispatch(addSpecies({
         name: species.name,
-        molecular_weight_kg_mol: 0.048,
+        molecular_weight_kg_mol: species['molecular weight [kg mol-1]'],
         properties: {},
       }));
     });
@@ -83,9 +79,9 @@ describe('RunSimulationButton (TS1 example)', () => {
       store.dispatch(addReaction({ ...reaction, id: reaction.id || 'test' }));
     });
     const options = ts1Example.mechanism["box model options"] || {};
-    if (options["simulation length [sec]"]) store.dispatch(setDuration(options["simulation length [sec]"]));
-    if (options["chemistry time step [sec]"]) store.dispatch(setTimeStep(options["chemistry time step [sec]"]));
-    if (options["output time step [sec]"]) store.dispatch(setOutputFrequency(options["output time step [sec]"]));
+    store.dispatch(setDuration(durationSeconds(options)));
+    store.dispatch(setTimeStep(stepSeconds(options, "chemistry time step")));
+    store.dispatch(setOutputFrequency(stepSeconds(options, "output time step")));
     store.dispatch(setConditions(ts1Example.mechanism.conditions));
     store.dispatch(setExampleFiles({ ...ts1Example.csv, data: ts1Example.mechanism.conditions?.data || [] }));
     store.dispatch(setExampleLoaded(false));
@@ -102,6 +98,6 @@ describe('RunSimulationButton (TS1 example)', () => {
 
     await waitFor(() => {
       expect(store.getState().simulation.status).toBe('succeeded');
-    });
-  });
+    }, { timeout: 120000 });
+  }, 120000);
 });

--- a/__tests__/helpers/boxModelOptions.js
+++ b/__tests__/helpers/boxModelOptions.js
@@ -1,0 +1,15 @@
+// Example mechanisms declare times in whichever unit suits them ([sec], [min], [hr], [hour],
+// [day]). Redux always holds seconds. These mirror the conversion ExampleLoader performs, so a
+// test fixture drives the solver with the same numbers the app would.
+
+export const durationSeconds = (options = {}) => {
+  if (options['simulation length [day]'] != null) return options['simulation length [day]'] * 86400
+  if (options['simulation length [hour]'] != null) return options['simulation length [hour]'] * 3600
+  if (options['simulation length [hr]'] != null) return options['simulation length [hr]'] * 3600
+  return options['simulation length [sec]']
+}
+
+export const stepSeconds = (options = {}, label) => {
+  if (options[`${label} [min]`] != null) return options[`${label} [min]`] * 60
+  return options[`${label} [sec]`]
+}

--- a/__tests__/solverPayloadContract.test.js
+++ b/__tests__/solverPayloadContract.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { MusicBox } from '@ncar/music-box'
+
+import { buildLocalSimulationPayload } from '../src/services/simulation/local/payload'
+import { runLocalSimulation } from '../src/services/simulation/local/run'
+import { TRACER_PREFIX } from '../src/services/simulation/local/tracer'
+import { durationSeconds, stepSeconds } from './helpers/boxModelOptions'
+
+import analyticalConfig from '@ncar/music-box/examples/analytical/my_config.json' with { type: 'json' }
+import chapmanConfig from '@ncar/music-box/examples/chapman/my_config.json' with { type: 'json' }
+import flowTubeConfig from '@ncar/music-box/examples/flow_tube/my_config.json' with { type: 'json' }
+import carbonBond5Config from '@ncar/music-box/examples/carbon_bond_5/my_config.json' with { type: 'json' }
+import ts1Config from '@ncar/music-box/examples/ts1/my_config.json' with { type: 'json' }
+
+// These tests validate the mechanism schema strictly and rejects any unrecognized or missing key.
+// The component tests in RunSimulationButton.*.test.jsx cover the React and Redux wiring, which
+// is a different concern and much cheaper to exercise.
+
+const EXAMPLES = [
+  ['analytical', analyticalConfig],
+  ['chapman', chapmanConfig],
+  ['flow_tube', flowTubeConfig],
+  ['carbon_bond_5', carbonBond5Config],
+  ['ts1', ts1Config],
+]
+
+const buildInputs = (config) => {
+  const options = config['box model options'] || {}
+  return {
+    mechanismData: {
+      // Empty species/reactions makes the builder fall back to the authored mechanism, which is
+      // the path an untouched example takes.
+      mechanism: { mechanism: config.mechanism },
+      species: [],
+      reactions: [],
+      currentExample: { name: config.mechanism?.name || 'example' },
+    },
+    conditions: {
+      conditions: config.conditions,
+      basic: {
+        timeStep: stepSeconds(options, 'chemistry time step'),
+        outputFrequency: stepSeconds(options, 'output time step'),
+        duration: durationSeconds(options),
+      },
+    },
+  }
+}
+
+describe('solver payload contract', () => {
+  it.each(EXAMPLES)('%s builds a payload the solver accepts', async (_name, config) => {
+    const { mechanismData, conditions } = buildInputs(config)
+    const { payload } = buildLocalSimulationPayload({ mechanismData, conditions })
+
+    await expect(MusicBox.fromJson(payload).solve()).resolves.toBeDefined()
+  }, 30000)
+
+  // MICM requires 'molecular weight [kg mol-1]' for the gas-phase species of a SURFACE reaction.
+  it('keeps molecular weight on species used by SURFACE reactions', () => {
+    const { mechanismData, conditions } = buildInputs(ts1Config)
+    const { payload } = buildLocalSimulationPayload({ mechanismData, conditions })
+
+    const surfaceSpecies = payload.mechanism.reactions
+      .filter((reaction) => reaction.type === 'SURFACE')
+      .map((reaction) => reaction['gas-phase species'])
+
+    expect(surfaceSpecies.length).toBeGreaterThan(0)
+
+    for (const name of surfaceSpecies) {
+      const species = payload.mechanism.species.find((entry) => entry?.name === name)
+      expect(species, `${name} missing from payload`).toBeDefined()
+      expect(
+        species['molecular weight [kg mol-1]'],
+        `${name} lost its molecular weight`
+      ).toBeGreaterThan(0)
+    }
+  })
+
+  // SURFACE reactions carry 'gas-phase products' rather than 'products', which is a separate
+  // branch of the tracer injection, and they are the reactions that require molecular weight.
+  it('injects tracers into SURFACE reactions without breaking the solve', async () => {
+    const surfaceOnly = structuredClone(ts1Config)
+    surfaceOnly.mechanism.reactions = surfaceOnly.mechanism.reactions.filter(
+      (reaction) => reaction.type === 'SURFACE'
+    )
+    expect(surfaceOnly.mechanism.reactions.length).toBeGreaterThan(0)
+
+    const { mechanismData, conditions } = buildInputs(surfaceOnly)
+    const { results, excludedResults } = await runLocalSimulation({ mechanismData, conditions })
+
+    expect(results.length).toBeGreaterThan(0)
+    const excludedKeys = Object.keys(excludedResults[0].concentrations)
+    expect(excludedKeys.length).toBe(surfaceOnly.mechanism.reactions.length)
+    expect(excludedKeys.every((key) => key.includes(TRACER_PREFIX))).toBe(true)
+  }, 30000)
+
+  it('solves with tracer instrumentation and keeps tracers out of the results', async () => {
+    const { mechanismData, conditions } = buildInputs(carbonBond5Config)
+    const { results, excludedResults } = await runLocalSimulation({ mechanismData, conditions })
+
+    expect(results.length).toBeGreaterThan(0)
+    expect(excludedResults.length).toBe(results.length)
+
+    const visibleKeys = Object.keys(results[0].concentrations)
+    expect(visibleKeys.length).toBeGreaterThan(0)
+    expect(visibleKeys.some((key) => key.includes(TRACER_PREFIX))).toBe(false)
+
+    const excludedKeys = Object.keys(excludedResults[0].concentrations)
+    expect(excludedKeys.length).toBeGreaterThan(0)
+    expect(excludedKeys.every((key) => key.includes(TRACER_PREFIX))).toBe(true)
+  }, 30000)
+})

--- a/src/services/simulation/local/payload.js
+++ b/src/services/simulation/local/payload.js
@@ -15,11 +15,10 @@ const toSolverSpecies = (species = []) => {
       return sp
     }
 
-    const { ['molecular weight [kg mol-1]']: _omitMolecularWeight, ...rest } = sp
     return {
-      ...rest,
-      'is third body': Object.prototype.hasOwnProperty.call(rest, 'is third body')
-        ? rest['is third body']
+      ...sp,
+      'is third body': Object.prototype.hasOwnProperty.call(sp, 'is third body')
+        ? sp['is third body']
         : false,
     }
   })

--- a/src/services/simulation/local/run.js
+++ b/src/services/simulation/local/run.js
@@ -100,7 +100,7 @@ export const runLocalSimulation = async ({ mechanismData, conditions }) => {
 
   productSpeciesToAdd.forEach((prodName) => {
     if (!species.some((sp) => sp?.name === prodName)) {
-      species.push({ name: prodName, 'molecular weight [kg mol-1]': 0.029 })
+      species.push({ name: prodName })
     }
   })
 

--- a/src/services/simulation/local/run.js
+++ b/src/services/simulation/local/run.js
@@ -82,9 +82,6 @@ const filterProductConcentrations = (results, excludeConcentrationKeys) => {
     excludedResults.push({ time: point.time, concentrations: excludedConcentrations })
   }
 
-  // console.log('Filtered Results:', filteredResults);
-  // console.log('Excluded Results:', excludedResults);
-
   return {
     filteredResults,
     excludedResults,
@@ -129,9 +126,7 @@ export const runLocalSimulation = async ({ mechanismData, conditions }) => {
     payload.mechanism.phases = phases
   }
 
-  // console.log('finalMechanism', payload)
   const rawResults = await MusicBox.fromJson(payload).solve()
-  // console.log('rawResults', rawResults)
   const normalizedPoints = normalizeSimulationResults(rawResults)
 
   if (normalizedPoints.length === 0) {


### PR DESCRIPTION
Each molecular weight read from the configuration is ignored. This causes TS1 mechanism to fail when it contains multiple surface reactions that require molecular weights.

This PR: 
- Reads molecular weights from the configuration, allowing the TS1 mechanism to run successfully.
- Replaces mocked solver with the real MICM solver which would have been helping identify bugs such as missing molecular weights.